### PR TITLE
add historyApiFallback to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = {
     filename: 'bundle.js'
   },
   devServer: {
+    historyApiFallback: true,
     contentBase: './dist',
     port: 3000,
     open: true


### PR DESCRIPTION
#### What does this PR do?
This PR includes a configuration for `webpack devServer` to serve some routes as api with react router instead of get an error abouth path not found.

#### Where should the reviewer start?
*  `webpack.config.js`
