### PR TITLE
fix bundle path to prevent issues for routing

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div class="app"></div>
-    <script src="bundle.js"></script>
+    <script src="/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the include path for `bundle.js` in the `index.html` file on `/dist` folder to prevent issues when trying to route the app with `react-router-dom`.

#### Where should the reviewer start?
* `/dist/index.html`

#### Any background context you want to provide?
When used `react-router-dom` and tried to create dinamically routing ie. `/container/:someId` the bundle was requested from `/container/` instead of `/`
